### PR TITLE
Fix max turn logic in ConversationData

### DIFF
--- a/src/semantic_kernel_chatbot/data_models/conversation_data.py
+++ b/src/semantic_kernel_chatbot/data_models/conversation_data.py
@@ -41,7 +41,7 @@ class ConversationData:
         If the history exceeds max_turns, the oldest turn is removed.
         """
         self.history.append(turn)
-        if len(self.history) >= self.max_turns:
+        if len(self.history) > self.max_turns:
             self.history.pop(0)
 
     def toMessages(self) -> list[dict[str, str]]:


### PR DESCRIPTION
## Summary
- keep full conversation history up to the configured limit

## Testing
- `make check-all`

------
https://chatgpt.com/codex/tasks/task_e_6840ecce4c5483268aaa14b289892f35